### PR TITLE
docs: correct typo in README.md adding dependencies section

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Defining _features_ in the root `Cargo.toml` is additive with the features defin
 1. Check if the dependency is already defined in the root `Cargo.toml`
     1. if **yes**, nothing to do, just take note of the enabled features
     2. if **no**, add it (make sure to use `default-features = false` if dependency is used in _no_std_ context)
-2. Add `new_dependecy = { workspace = true }` to the required crate
+2. Add `new_dependency = { workspace = true }` to the required crate
 3. In case dependency is defined with `default-features = false` but you need it in _std_ context, add `features = ["std"]` to the required crate.
 
 ## Further Reading


### PR DESCRIPTION
im correct some typos on docs file README.md
fix typo 'dependecy' to 'dependency'