### PR TITLE
docs: add install via script section and troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,29 @@ $ cargo build --release
 # show list of available commands
 $ ./target/release/uomi --help
 ```
+## Install via Script (Quick Setup)
+
+For users who want a one-command installation, a simplified installer script is available:
+
+```bash
+git clone --recurse-submodules https://github.com/Uomi-network/uomi-node.git
+cd uomi-node
+bash scripts/install-simple.sh
+```
+
+## After installation:
+```bash
+which uomi
+uomi --help
+sudo systemctl status uomi
+```
+## Troubleshooting
+protoc not found
+
+Install protobuf:
+```bash
+sudo apt-get install protobuf-compiler libprotobuf-dev
+```
 
 ## Running a node
 


### PR DESCRIPTION
## What
- Added "Install via Script" section describing how to use scripts/install-simple.sh.
- Added Troubleshooting guide for common issues:
  - protoc not found

## Why
- Lower the barrier for new node operators.
- Provide quick reference for common errors and their fixes.

## How to test
- Run the script in a fresh Ubuntu 22.04/24.04 environment.

## Notes
- Keeps existing build instructions intact.
- This is an additional section to improve developer/operator experience.
