### PR TITLE
fix(precompiles): allow closure-call pattern in mock_account! and fix out-of-bounds slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,29 @@ $ cargo build --release
 # show list of available commands
 $ ./target/release/uomi --help
 ```
+## Install via Script (Quick Setup)
+
+For users who want a one-command installation, a simplified installer script is available:
+
+```bash
+git clone --recurse-submodules https://github.com/Uomi-network/uomi-node.git
+cd uomi-node
+bash scripts/install-simple.sh
+```
+
+## After installation:
+```bash
+which uomi
+uomi --help
+sudo systemctl status uomi
+```
+## Troubleshooting
+protoc not found
+
+Install protobuf:
+```bash
+sudo apt-get install protobuf-compiler libprotobuf-dev
+```
 
 ## Running a node
 


### PR DESCRIPTION
- Add #[allow(clippy::redundant_closure_call)] in mock_account! From impl
- Fix out-of-bounds slice when constructing H160 from (u32, u128)
- No behavior change; improves lint hygiene and prevents panic risk in tests

How to verify:
  cargo clippy -p precompile-utils -- -D warnings
  cargo test   -p precompile-utils
